### PR TITLE
Flake8 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: python
+sudo: false
+
+git:
+  submodules: true
+
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+
+before_install:
+  - git clone https://github.com/raspberrpi/tools rpi-tools --depth=1
+  - export PATH=$PATH:$HOME/rpi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin
+  - export ARCH=arm
+  - export CCPREFIX=$HOME/rpi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin/arm-linux-gnueabihf-
+  - export CC=arm-linux-gnueabihf-gcc
+
+env:
+  - CXX=g++-4.8
+
+install:
+  - cd library
+  - python setup.py bdist_wheel

--- a/examples/SK6812_lowlevel.py
+++ b/examples/SK6812_lowlevel.py
@@ -12,32 +12,32 @@ import time
 import _rpi_ws281x as ws
 
 # LED configuration.
-LED_CHANNEL    = 0
-LED_COUNT      = 16         # How many LEDs to light.
-LED_FREQ_HZ    = 800000     # Frequency of the LED signal.  Should be 800khz or 400khz.
-LED_DMA_NUM    = 10         # DMA channel to use, can be 0-14.
-LED_GPIO       = 18         # GPIO connected to the LED signal line.  Must support PWM!
+LED_CHANNEL = 0
+LED_COUNT = 16              # How many LEDs to light.
+LED_FREQ_HZ = 800000        # Frequency of the LED signal.  Should be 800khz or 400khz.
+LED_DMA_NUM = 10            # DMA channel to use, can be 0-14.
+LED_GPIO = 18               # GPIO connected to the LED signal line.  Must support PWM!
 LED_BRIGHTNESS = 255        # Set to 0 for darkest and 255 for brightest
-LED_INVERT     = 0          # Set to 1 to invert the LED signal, good if using NPN
-							# transistor as a 3.3V->5V level converter.  Keep at 0
-							# for a normal/non-inverted signal.
-#LED_STRIP      = ws.WS2811_STRIP_RGB
-#LED_STRIP      = ws.WS2811_STRIP_GBR
-#LED_STRIP      = ws.SK6812_STRIP_RGBW
-LED_STRIP      = ws.SK6812W_STRIP
+LED_INVERT = 0              # Set to 1 to invert the LED signal, good if using NPN
+#                             transistor as a 3.3V->5V level converter.  Keep at 0
+#                             for a normal/non-inverted signal.
+# LED_STRIP = ws.WS2811_STRIP_RGB
+# LED_STRIP = ws.WS2811_STRIP_GBR
+# LED_STRIP = ws.SK6812_STRIP_RGBW
+LED_STRIP = ws.SK6812W_STRIP
 
 
 # Define colors which will be used by the example.  Each color is an unsigned
 # 32-bit value where the lower 24 bits define the red, green, blue data (each
 # being 8 bits long).
-DOT_COLORS = [  0x200000,   # red
-				0x201000,   # orange
-				0x202000,   # yellow
-				0x002000,   # green
-				0x002020,   # lightblue
-				0x000020,   # blue
-				0x100010,   # purple
-				0x200010 ]  # pink
+DOT_COLORS = [0x200000,   # red
+              0x201000,   # orange
+              0x202000,   # yellow
+              0x002000,   # green
+              0x002020,   # lightblue
+              0x000020,   # blue
+              0x100010,   # purple
+              0x200010]   # pink
 
 
 # Create a ws2811_t structure from the LED configuration.
@@ -67,38 +67,38 @@ ws.ws2811_t_dmanum_set(leds, LED_DMA_NUM)
 # Initialize library with LED configuration.
 resp = ws.ws2811_init(leds)
 if resp != ws.WS2811_SUCCESS:
-	message = ws.ws2811_get_return_t_str(resp)
-	raise RuntimeError('ws2811_init failed with code {0} ({1})'.format(resp, message))
+    message = ws.ws2811_get_return_t_str(resp)
+    raise RuntimeError('ws2811_init failed with code {0} ({1})'.format(resp, message))
 
 # Wrap following code in a try/finally to ensure cleanup functions are called
 # after library is initialized.
 try:
-	offset = 0
-	while True:
-		# Update each LED color in the buffer.
-		for i in range(LED_COUNT):
-			# Pick a color based on LED position and an offset for animation.
-			color = DOT_COLORS[(i + offset) % len(DOT_COLORS)]
+    offset = 0
+    while True:
+        # Update each LED color in the buffer.
+        for i in range(LED_COUNT):
+            # Pick a color based on LED position and an offset for animation.
+            color = DOT_COLORS[(i + offset) % len(DOT_COLORS)]
 
-			# Set the LED color buffer value.
-			ws.ws2811_led_set(channel, i, color)
+            # Set the LED color buffer value.
+            ws.ws2811_led_set(channel, i, color)
 
-		# Send the LED color data to the hardware.
-		resp = ws.ws2811_render(leds)
-		if resp != ws.WS2811_SUCCESS:
-			message = ws.ws2811_get_return_t_str(resp)
-			raise RuntimeError('ws2811_render failed with code {0} ({1})'.format(resp, message))
+        # Send the LED color data to the hardware.
+        resp = ws.ws2811_render(leds)
+        if resp != ws.WS2811_SUCCESS:
+            message = ws.ws2811_get_return_t_str(resp)
+            raise RuntimeError('ws2811_render failed with code {0} ({1})'.format(resp, message))
 
-		# Delay for a small period of time.
-		time.sleep(0.25)
+        # Delay for a small period of time.
+        time.sleep(0.25)
 
-		# Increase offset to animate colors moving.  Will eventually overflow, which
-		# is fine.
-		offset += 1
+        # Increase offset to animate colors moving.  Will eventually overflow, which
+        # is fine.
+        offset += 1
 
 finally:
-	# Ensure ws2811_fini is called before the program quits.
-	ws.ws2811_fini(leds)
-	# Example of calling delete function to clean up structure memory.  Isn't
-	# strictly necessary at the end of the program execution here, but is good practice.
-	ws.delete_ws2811_t(leds)
+    # Ensure ws2811_fini is called before the program quits.
+    ws.ws2811_fini(leds)
+    # Example of calling delete function to clean up structure memory.  Isn't
+    # strictly necessary at the end of the program execution here, but is good practice.
+    ws.delete_ws2811_t(leds)

--- a/examples/SK6812_strandtest.py
+++ b/examples/SK6812_strandtest.py
@@ -5,103 +5,108 @@
 # various animations on a strip of NeoPixels.
 import time
 
-from rpi_ws281x import *
+from rpi_ws281x import Color, PixelStrip, ws
 
 
 # LED strip configuration:
-LED_COUNT      = 40      # Number of LED pixels.
-LED_PIN        = 18      # GPIO pin connected to the pixels (must support PWM!).
-LED_FREQ_HZ    = 800000  # LED signal frequency in hertz (usually 800khz)
-LED_DMA        = 10      # DMA channel to use for generating signal (try 10)
-LED_BRIGHTNESS = 255     # Set to 0 for darkest and 255 for brightest
-LED_INVERT     = False   # True to invert the signal (when using NPN transistor level shift)
-LED_CHANNEL    = 0
-LED_STRIP      = ws.SK6812_STRIP_RGBW
-#LED_STRIP      = ws.SK6812W_STRIP
+LED_COUNT = 40         # Number of LED pixels.
+LED_PIN = 18           # GPIO pin connected to the pixels (must support PWM!).
+LED_FREQ_HZ = 800000   # LED signal frequency in hertz (usually 800khz)
+LED_DMA = 10           # DMA channel to use for generating signal (try 10)
+LED_BRIGHTNESS = 255   # Set to 0 for darkest and 255 for brightest
+LED_INVERT = False     # True to invert the signal (when using NPN transistor level shift)
+LED_CHANNEL = 0
+LED_STRIP = ws.SK6812_STRIP_RGBW
+# LED_STRIP = ws.SK6812W_STRIP
 
 
 # Define functions which animate LEDs in various ways.
 def colorWipe(strip, color, wait_ms=50):
-	"""Wipe color across display a pixel at a time."""
-	for i in range(strip.numPixels()):
-		strip.setPixelColor(i, color)
-		strip.show()
-		time.sleep(wait_ms/1000.0)
+    """Wipe color across display a pixel at a time."""
+    for i in range(strip.numPixels()):
+        strip.setPixelColor(i, color)
+        strip.show()
+        time.sleep(wait_ms / 1000.0)
+
 
 def theaterChase(strip, color, wait_ms=50, iterations=10):
-	"""Movie theater light style chaser animation."""
-	for j in range(iterations):
-		for q in range(3):
-			for i in range(0, strip.numPixels(), 3):
-				strip.setPixelColor(i+q, color)
-			strip.show()
-			time.sleep(wait_ms/1000.0)
-			for i in range(0, strip.numPixels(), 3):
-				strip.setPixelColor(i+q, 0)
+    """Movie theater light style chaser animation."""
+    for j in range(iterations):
+        for q in range(3):
+            for i in range(0, strip.numPixels(), 3):
+                strip.setPixelColor(i + q, color)
+            strip.show()
+            time.sleep(wait_ms / 1000.0)
+            for i in range(0, strip.numPixels(), 3):
+                strip.setPixelColor(i + q, 0)
+
 
 def wheel(pos):
-	"""Generate rainbow colors across 0-255 positions."""
-	if pos < 85:
-		return Color(pos * 3, 255 - pos * 3, 0)
-	elif pos < 170:
-		pos -= 85
-		return Color(255 - pos * 3, 0, pos * 3)
-	else:
-		pos -= 170
-		return Color(0, pos * 3, 255 - pos * 3)
+    """Generate rainbow colors across 0-255 positions."""
+    if pos < 85:
+        return Color(pos * 3, 255 - pos * 3, 0)
+    elif pos < 170:
+        pos -= 85
+        return Color(255 - pos * 3, 0, pos * 3)
+    else:
+        pos -= 170
+        return Color(0, pos * 3, 255 - pos * 3)
+
 
 def rainbow(strip, wait_ms=20, iterations=1):
-	"""Draw rainbow that fades across all pixels at once."""
-	for j in range(256*iterations):
-		for i in range(strip.numPixels()):
-			strip.setPixelColor(i, wheel((i+j) & 255))
-		strip.show()
-		time.sleep(wait_ms/1000.0)
+    """Draw rainbow that fades across all pixels at once."""
+    for j in range(256 * iterations):
+        for i in range(strip.numPixels()):
+            strip.setPixelColor(i, wheel((i + j) & 255))
+        strip.show()
+        time.sleep(wait_ms / 1000.0)
+
 
 def rainbowCycle(strip, wait_ms=20, iterations=5):
-	"""Draw rainbow that uniformly distributes itself across all pixels."""
-	for j in range(256*iterations):
-		for i in range(strip.numPixels()):
-			strip.setPixelColor(i, wheel(((i * 256 // strip.numPixels()) + j) & 255))
-		strip.show()
-		time.sleep(wait_ms/1000.0)
+    """Draw rainbow that uniformly distributes itself across all pixels."""
+    for j in range(256 * iterations):
+        for i in range(strip.numPixels()):
+            strip.setPixelColor(i, wheel(((i * 256 // strip.numPixels()) + j) & 255))
+        strip.show()
+        time.sleep(wait_ms / 1000.0)
+
 
 def theaterChaseRainbow(strip, wait_ms=50):
-	"""Rainbow movie theater light style chaser animation."""
-	for j in range(256):
-		for q in range(3):
-			for i in range(0, strip.numPixels(), 3):
-				strip.setPixelColor(i+q, wheel((i+j) % 255))
-			strip.show()
-			time.sleep(wait_ms/1000.0)
-			for i in range(0, strip.numPixels(), 3):
-				strip.setPixelColor(i+q, 0)
+    """Rainbow movie theater light style chaser animation."""
+    for j in range(256):
+        for q in range(3):
+            for i in range(0, strip.numPixels(), 3):
+                strip.setPixelColor(i + q, wheel((i + j) % 255))
+            strip.show()
+            time.sleep(wait_ms / 1000.0)
+            for i in range(0, strip.numPixels(), 3):
+                strip.setPixelColor(i + q, 0)
 
 
 # Main program logic follows:
 if __name__ == '__main__':
-	# Create NeoPixel object with appropriate configuration.
-	strip = Adafruit_NeoPixel(LED_COUNT, LED_PIN, LED_FREQ_HZ, LED_DMA, LED_INVERT, LED_BRIGHTNESS, LED_CHANNEL, LED_STRIP)
-	# Intialize the library (must be called once before other functions).
-	strip.begin()
+    # Create NeoPixel object with appropriate configuration.
+    strip = PixelStrip(LED_COUNT, LED_PIN, LED_FREQ_HZ, LED_DMA, LED_INVERT, LED_BRIGHTNESS, LED_CHANNEL, LED_STRIP)
+    # Intialize the library (must be called once before other functions).
+    strip.begin()
 
-	print ('Press Ctrl-C to quit.')
-	while True:
-		# Color wipe animations.
-		colorWipe(strip, Color(255, 0, 0))  # Red wipe
-		colorWipe(strip, Color(0, 255, 0))  # Blue wipe
-		colorWipe(strip, Color(0, 0, 255))  # Green wipe
-		colorWipe(strip, Color(0, 0, 0, 255))  # White wipe
-		colorWipe(strip, Color(255, 255, 255))  # Composite White wipe
-		colorWipe(strip, Color(255, 255, 255, 255))  # Composite White + White LED wipe
-		# Theater chase animations.
-		theaterChase(strip, Color(127, 0, 0))  # Red theater chase
-		theaterChase(strip, Color(0, 127, 0))  # Green theater chase
-		theaterChase(strip, Color(0, 0, 127))  # Blue theater chase
-		theaterChase(strip, Color(0, 0, 0, 127))  # White theater chase
-		theaterChase(strip, Color(127, 127, 127, 0))  # Composite White theater chase
-		theaterChase(strip, Color(127, 127, 127, 127))  # Composite White + White theater chase
-		# Rainbow animations.
-		rainbow(strip)
-		rainbowCycle(strip)
-		theaterChaseRainbow(strip)
+    print('Press Ctrl-C to quit.')
+    while True:
+        # Color wipe animations.
+        colorWipe(strip, Color(255, 0, 0))  # Red wipe
+        colorWipe(strip, Color(0, 255, 0))  # Blue wipe
+        colorWipe(strip, Color(0, 0, 255))  # Green wipe
+        colorWipe(strip, Color(0, 0, 0, 255))  # White wipe
+        colorWipe(strip, Color(255, 255, 255))  # Composite White wipe
+        colorWipe(strip, Color(255, 255, 255, 255))  # Composite White + White LED wipe
+        # Theater chase animations.
+        theaterChase(strip, Color(127, 0, 0))  # Red theater chase
+        theaterChase(strip, Color(0, 127, 0))  # Green theater chase
+        theaterChase(strip, Color(0, 0, 127))  # Blue theater chase
+        theaterChase(strip, Color(0, 0, 0, 127))  # White theater chase
+        theaterChase(strip, Color(127, 127, 127, 0))  # Composite White theater chase
+        theaterChase(strip, Color(127, 127, 127, 127))  # Composite White + White theater chase
+        # Rainbow animations.
+        rainbow(strip)
+        rainbowCycle(strip)
+        theaterChaseRainbow(strip)

--- a/examples/SK6812_white_test.py
+++ b/examples/SK6812_white_test.py
@@ -5,48 +5,48 @@
 # various animations on a strip of NeoPixels.
 import time
 
-from rpi_ws281x import *
+from rpi_ws281x import Color, PixelStrip, ws
 
 # LED strip configuration:
-LED_COUNT      = 30      # Number of LED pixels.
-LED_PIN        = 18      # GPIO pin connected to the pixels (must support PWM!).
-LED_FREQ_HZ    = 800000  # LED signal frequency in hertz (usually 800khz)
-LED_DMA        = 10      # DMA channel to use for generating signal (try 10)
-LED_BRIGHTNESS = 255     # Set to 0 for darkest and 255 for brightest
-LED_INVERT     = False   # True to invert the signal (when using NPN transistor level shift)
-LED_CHANNEL    = 0
-#LED_STRIP      = ws.SK6812_STRIP_RGBW
-LED_STRIP      = ws.SK6812W_STRIP
+LED_COUNT = 30        # Number of LED pixels.
+LED_PIN = 18          # GPIO pin connected to the pixels (must support PWM!).
+LED_FREQ_HZ = 800000  # LED signal frequency in hertz (usually 800khz)
+LED_DMA = 10          # DMA channel to use for generating signal (try 10)
+LED_BRIGHTNESS = 255  # Set to 0 for darkest and 255 for brightest
+LED_INVERT = False    # True to invert the signal (when using NPN transistor level shift)
+LED_CHANNEL = 0
+# LED_STRIP = ws.SK6812_STRIP_RGBW
+LED_STRIP = ws.SK6812W_STRIP
 
 
 # Define functions which animate LEDs in various ways.
 def colorWipe(strip, color, wait_ms=50):
-	"""Wipe color across display a pixel at a time."""
-	for i in range(strip.numPixels()):
-		strip.setPixelColor(i, color)
-		strip.show()
-		time.sleep(wait_ms/1000.0)
+    """Wipe color across display a pixel at a time."""
+    for i in range(strip.numPixels()):
+        strip.setPixelColor(i, color)
+        strip.show()
+        time.sleep(wait_ms / 1000.0)
 
 
 # Main program logic follows:
 if __name__ == '__main__':
-	# Create NeoPixel object with appropriate configuration.
-	strip = Adafruit_NeoPixel(LED_COUNT, LED_PIN, LED_FREQ_HZ, LED_DMA, LED_INVERT, LED_BRIGHTNESS, LED_CHANNEL, LED_STRIP)
-	# Intialize the library (must be called once before other functions).
-	strip.begin()
+    # Create PixelStrip object with appropriate configuration.
+    strip = PixelStrip(LED_COUNT, LED_PIN, LED_FREQ_HZ, LED_DMA, LED_INVERT, LED_BRIGHTNESS, LED_CHANNEL, LED_STRIP)
+    # Intialize the library (must be called once before other functions).
+    strip.begin()
 
-	print ('Press Ctrl-C to quit.')
-	while True:
-		# Color wipe animations.
-		colorWipe(strip, Color(255, 0, 0), 0)  # Red wipe
-		time.sleep(2)
-		colorWipe(strip, Color(0, 255, 0), 0)  # Blue wipe
-		time.sleep(2)
-		colorWipe(strip, Color(0, 0, 255), 0)  # Green wipe
-		time.sleep(2)
-		colorWipe(strip, Color(0, 0, 0, 255), 0)  # White wipe
-		time.sleep(2)
-		colorWipe(strip, Color(255, 255, 255), 0)  # Composite White wipe
-		time.sleep(2)
-		colorWipe(strip, Color(255, 255, 255, 255), 0)  # Composite White + White LED wipe
-		time.sleep(2)
+    print('Press Ctrl-C to quit.')
+    while True:
+        # Color wipe animations.
+        colorWipe(strip, Color(255, 0, 0), 0)  # Red wipe
+        time.sleep(2)
+        colorWipe(strip, Color(0, 255, 0), 0)  # Blue wipe
+        time.sleep(2)
+        colorWipe(strip, Color(0, 0, 255), 0)  # Green wipe
+        time.sleep(2)
+        colorWipe(strip, Color(0, 0, 0, 255), 0)  # White wipe
+        time.sleep(2)
+        colorWipe(strip, Color(255, 255, 255), 0)  # Composite White wipe
+        time.sleep(2)
+        colorWipe(strip, Color(255, 255, 255, 255), 0)  # Composite White + White LED wipe
+        time.sleep(2)

--- a/examples/lowlevel.py
+++ b/examples/lowlevel.py
@@ -12,27 +12,27 @@ import time
 import _rpi_ws281x as ws
 
 # LED configuration.
-LED_CHANNEL    = 0
-LED_COUNT      = 16         # How many LEDs to light.
-LED_FREQ_HZ    = 800000     # Frequency of the LED signal.  Should be 800khz or 400khz.
-LED_DMA_NUM    = 10         # DMA channel to use, can be 0-14.
-LED_GPIO       = 18         # GPIO connected to the LED signal line.  Must support PWM!
+LED_CHANNEL = 0
+LED_COUNT = 16              # How many LEDs to light.
+LED_FREQ_HZ = 800000        # Frequency of the LED signal.  Should be 800khz or 400khz.
+LED_DMA_NUM = 10            # DMA channel to use, can be 0-14.
+LED_GPIO = 18               # GPIO connected to the LED signal line.  Must support PWM!
 LED_BRIGHTNESS = 255        # Set to 0 for darkest and 255 for brightest
-LED_INVERT     = 0          # Set to 1 to invert the LED signal, good if using NPN
-							# transistor as a 3.3V->5V level converter.  Keep at 0
-							# for a normal/non-inverted signal.
+LED_INVERT = 0              # Set to 1 to invert the LED signal, good if using NPN
+#                             transistor as a 3.3V->5V level converter.  Keep at 0
+#                             for a normal/non-inverted signal.
 
 # Define colors which will be used by the example.  Each color is an unsigned
 # 32-bit value where the lower 24 bits define the red, green, blue data (each
 # being 8 bits long).
-DOT_COLORS = [  0x200000,   # red
-				0x201000,   # orange
-				0x202000,   # yellow
-				0x002000,   # green
-				0x002020,   # lightblue
-				0x000020,   # blue
-				0x100010,   # purple
-				0x200010 ]  # pink
+DOT_COLORS = [0x200000,   # red
+              0x201000,   # orange
+              0x202000,   # yellow
+              0x002000,   # green
+              0x002020,   # lightblue
+              0x000020,   # blue
+              0x100010,   # purple
+              0x200010]  # pink
 
 
 # Create a ws2811_t structure from the LED configuration.
@@ -61,38 +61,38 @@ ws.ws2811_t_dmanum_set(leds, LED_DMA_NUM)
 # Initialize library with LED configuration.
 resp = ws.ws2811_init(leds)
 if resp != ws.WS2811_SUCCESS:
-	message = ws.ws2811_get_return_t_str(resp)
-	raise RuntimeError('ws2811_init failed with code {0} ({1})'.format(resp, message))
+    message = ws.ws2811_get_return_t_str(resp)
+    raise RuntimeError('ws2811_init failed with code {0} ({1})'.format(resp, message))
 
 # Wrap following code in a try/finally to ensure cleanup functions are called
 # after library is initialized.
 try:
-	offset = 0
-	while True:
-		# Update each LED color in the buffer.
-		for i in range(LED_COUNT):
-			# Pick a color based on LED position and an offset for animation.
-			color = DOT_COLORS[(i + offset) % len(DOT_COLORS)]
+    offset = 0
+    while True:
+        # Update each LED color in the buffer.
+        for i in range(LED_COUNT):
+            # Pick a color based on LED position and an offset for animation.
+            color = DOT_COLORS[(i + offset) % len(DOT_COLORS)]
 
-			# Set the LED color buffer value.
-			ws.ws2811_led_set(channel, i, color)
+            # Set the LED color buffer value.
+            ws.ws2811_led_set(channel, i, color)
 
-		# Send the LED color data to the hardware.
-		resp = ws.ws2811_render(leds)
-		if resp != ws.WS2811_SUCCESS:
-			message = ws.ws2811_get_return_t_str(resp)
-			raise RuntimeError('ws2811_render failed with code {0} ({1})'.format(resp, message))
+        # Send the LED color data to the hardware.
+        resp = ws.ws2811_render(leds)
+        if resp != ws.WS2811_SUCCESS:
+            message = ws.ws2811_get_return_t_str(resp)
+            raise RuntimeError('ws2811_render failed with code {0} ({1})'.format(resp, message))
 
-		# Delay for a small period of time.
-		time.sleep(0.25)
+        # Delay for a small period of time.
+        time.sleep(0.25)
 
-		# Increase offset to animate colors moving.  Will eventually overflow, which
-		# is fine.
-		offset += 1
+        # Increase offset to animate colors moving.  Will eventually overflow, which
+        # is fine.
+        offset += 1
 
 finally:
-	# Ensure ws2811_fini is called before the program quits.
-	ws.ws2811_fini(leds)
-	# Example of calling delete function to clean up structure memory.  Isn't
-	# strictly necessary at the end of the program execution here, but is good practice.
-	ws.delete_ws2811_t(leds)
+    # Ensure ws2811_fini is called before the program quits.
+    ws.ws2811_fini(leds)
+    # Example of calling delete function to clean up structure memory.  Isn't
+    # strictly necessary at the end of the program execution here, but is good practice.
+    ws.delete_ws2811_t(leds)

--- a/examples/multistrandtest.py
+++ b/examples/multistrandtest.py
@@ -5,74 +5,83 @@
 # various animations on a strip of NeoPixels.
 import time
 
-from rpi_ws281x import *
+from rpi_ws281x import ws, Color, Adafruit_NeoPixel
 
 # LED strip configuration:
-LED_1_COUNT      = 30      # Number of LED pixels.
-LED_1_PIN        = 18      # GPIO pin connected to the pixels (must support PWM! GPIO 13 and 18 on RPi 3).
-LED_1_FREQ_HZ    = 800000  # LED signal frequency in hertz (usually 800khz)
-LED_1_DMA        = 10      # DMA channel to use for generating signal (Between 1 and 14)
-LED_1_BRIGHTNESS = 128     # Set to 0 for darkest and 255 for brightest
-LED_1_INVERT     = False   # True to invert the signal (when using NPN transistor level shift)
-LED_1_CHANNEL    = 0       # 0 or 1
-LED_1_STRIP      = ws.SK6812_STRIP_GRBW
+LED_1_COUNT = 30        # Number of LED pixels.
+LED_1_PIN = 18          # GPIO pin connected to the pixels (must support PWM! GPIO 13 and 18 on RPi 3).
+LED_1_FREQ_HZ = 800000  # LED signal frequency in hertz (usually 800khz)
+LED_1_DMA = 10          # DMA channel to use for generating signal (Between 1 and 14)
+LED_1_BRIGHTNESS = 128  # Set to 0 for darkest and 255 for brightest
+LED_1_INVERT = False    # True to invert the signal (when using NPN transistor level shift)
+LED_1_CHANNEL = 0       # 0 or 1
+LED_1_STRIP = ws.SK6812_STRIP_GRBW
 
-LED_2_COUNT      = 15      # Number of LED pixels.
-LED_2_PIN        = 13      # GPIO pin connected to the pixels (must support PWM! GPIO 13 or 18 on RPi 3).
-LED_2_FREQ_HZ    = 800000  # LED signal frequency in hertz (usually 800khz)
-LED_2_DMA        = 11      # DMA channel to use for generating signal (Between 1 and 14)
-LED_2_BRIGHTNESS = 128     # Set to 0 for darkest and 255 for brightest
-LED_2_INVERT     = False   # True to invert the signal (when using NPN transistor level shift)
-LED_2_CHANNEL    = 1       # 0 or 1
-LED_2_STRIP      = ws.WS2811_STRIP_GRB
+LED_2_COUNT = 15        # Number of LED pixels.
+LED_2_PIN = 13          # GPIO pin connected to the pixels (must support PWM! GPIO 13 or 18 on RPi 3).
+LED_2_FREQ_HZ = 800000  # LED signal frequency in hertz (usually 800khz)
+LED_2_DMA = 11          # DMA channel to use for generating signal (Between 1 and 14)
+LED_2_BRIGHTNESS = 128  # Set to 0 for darkest and 255 for brightest
+LED_2_INVERT = False    # True to invert the signal (when using NPN transistor level shift)
+LED_2_CHANNEL = 1       # 0 or 1
+LED_2_STRIP = ws.WS2811_STRIP_GRB
+
 
 def multiColorWipe(color1, color2, wait_ms=5):
-	global strip1
-	global strip2
-	"""Wipe color across multiple LED strips a pixel at a time."""
-	for i in range(strip1.numPixels()):
-		if i % 2:
-			# even number
-			strip1.setPixelColor(i, color1)
-			strip2.setPixelColor(i / 2, color2)
-			strip1.show()
-			time.sleep(wait_ms/1000.0)
-			strip2.show()
-			time.sleep(wait_ms/1000.0)
-		else:
-			# odd number
-			strip1.setPixelColor(i, color1)
-			strip1.show()
-			time.sleep(wait_ms/1000.0)
-	time.sleep(1)
+    """Wipe color across multiple LED strips a pixel at a time."""
+    global strip1
+    global strip2
+
+    for i in range(strip1.numPixels()):
+        if i % 2:
+            # even number
+            strip1.setPixelColor(i, color1)
+            strip2.setPixelColor(i / 2, color2)
+            strip1.show()
+            time.sleep(wait_ms / 1000.0)
+            strip2.show()
+            time.sleep(wait_ms / 1000.0)
+        else:
+            # odd number
+            strip1.setPixelColor(i, color1)
+            strip1.show()
+            time.sleep(wait_ms / 1000.0)
+
+    time.sleep(1)
+
 
 def blackout(strip):
-	for i in range(max(strip1.numPixels(), strip1.numPixels())):
-		strip.setPixelColor(i, Color(0,0,0))
-		strip.show()
+    for i in range(max(strip1.numPixels(), strip1.numPixels())):
+        strip.setPixelColor(i, Color(0, 0, 0))
+        strip.show()
+
 
 # Main program logic follows:
 if __name__ == '__main__':
-	# Create NeoPixel objects with appropriate configuration for each strip.
-	strip1 = Adafruit_NeoPixel(LED_1_COUNT, LED_1_PIN, LED_1_FREQ_HZ, LED_1_DMA, LED_1_INVERT, LED_1_BRIGHTNESS, LED_1_CHANNEL, LED_1_STRIP)
-	strip2 = Adafruit_NeoPixel(LED_2_COUNT, LED_2_PIN, LED_2_FREQ_HZ, LED_2_DMA, LED_2_INVERT, LED_2_BRIGHTNESS, LED_2_CHANNEL, LED_2_STRIP)
+    # Create NeoPixel objects with appropriate configuration for each strip.
+    strip1 = Adafruit_NeoPixel(LED_1_COUNT, LED_1_PIN, LED_1_FREQ_HZ,
+                               LED_1_DMA, LED_1_INVERT, LED_1_BRIGHTNESS,
+                               LED_1_CHANNEL, LED_1_STRIP)
 
-	# Intialize the library (must be called once before other functions).
-	strip1.begin()
-	strip2.begin()
+    strip2 = Adafruit_NeoPixel(LED_2_COUNT, LED_2_PIN, LED_2_FREQ_HZ,
+                               LED_2_DMA, LED_2_INVERT, LED_2_BRIGHTNESS,
+                               LED_2_CHANNEL, LED_2_STRIP)
 
-	print ('Press Ctrl-C to quit.')
+    # Intialize the library (must be called once before other functions).
+    strip1.begin()
+    strip2.begin()
 
-	# Black out any LEDs that may be still on for the last run
-	blackout(strip1)
-	blackout(strip2)
+    print('Press Ctrl-C to quit.')
 
-	while True:
+    # Black out any LEDs that may be still on for the last run
+    blackout(strip1)
+    blackout(strip2)
 
-		# Multi Color wipe animations.
-		multiColorWipe(Color(255, 0, 0), Color(255, 0, 0))  # Red wipe
-		multiColorWipe(Color(0, 255, 0), Color(0, 255, 0))  # Blue wipe
-		multiColorWipe(Color(0, 0, 255), Color(0, 0, 255))  # Green wipe
-		multiColorWipe(Color(255, 255, 255), Color(255, 255, 255))  # Composite White wipe
-		multiColorWipe(Color(0, 0, 0, 255), Color(0, 0, 0))  # White wipe
-		multiColorWipe(Color(255, 255, 255, 255), Color(0, 0, 0))  # Composite White + White LED wipe
+    while True:
+        # Multi Color wipe animations.
+        multiColorWipe(Color(255, 0, 0), Color(255, 0, 0))  # Red wipe
+        multiColorWipe(Color(0, 255, 0), Color(0, 255, 0))  # Blue wipe
+        multiColorWipe(Color(0, 0, 255), Color(0, 0, 255))  # Green wipe
+        multiColorWipe(Color(255, 255, 255), Color(255, 255, 255))  # Composite White wipe
+        multiColorWipe(Color(0, 0, 0, 255), Color(0, 0, 0))  # White wipe
+        multiColorWipe(Color(255, 255, 255, 255), Color(0, 0, 0))  # Composite White + White LED wipe

--- a/examples/neopixelclock.py
+++ b/examples/neopixelclock.py
@@ -8,15 +8,14 @@
 
 import time
 import datetime
-import math
 
-from rpi_ws281x import *
+from rpi_ws281x import Adafruit_NeoPixel, Color
 
 # LED strip configuration:
-LED_COUNT = 12      # Number of LED pixels.
-LED_PIN = 18      # GPIO pin connected to the pixels (must support PWM!).
+LED_COUNT = 12        # Number of LED pixels.
+LED_PIN = 18          # GPIO pin connected to the pixels (must support PWM!).
 LED_FREQ_HZ = 800000  # LED signal frequency in hertz (usually 800khz)
-LED_DMA = 10       # DMA channel to use for generating signal (try 10)
+LED_DMA = 10          # DMA channel to use for generating signal (try 10)
 LED_BRIGHTNESS = 255  # Set to 0 for darkest and 255 for brightest
 # True to invert the signal (when using NPN transistor level shift)
 LED_INVERT = False
@@ -45,6 +44,7 @@ if __name__ == '__main__':
         second = now.second / 5
         secondmodulo = now.second % 5
         timeslot_in_microseconds = secondmodulo * 1000000 + now.microsecond
+
         for i in range(0, strip.numPixels(), 1):
             secondplusone = second + 1 if(second < 11) else 0
             secondminusone = second - 1 if(second > 0) else 11
@@ -57,6 +57,7 @@ if __name__ == '__main__':
                 else:
                     colorarray[0] = 382 - \
                         int(0.0000508 * timeslot_in_microseconds)
+
             if i == secondplusone:
                 colorarray[0] = int(0.0000256 * timeslot_in_microseconds)
             if i == secondminusone:
@@ -66,7 +67,9 @@ if __name__ == '__main__':
                 colorarray[2] = 200
             if i == hour:
                 colorarray[1] = 200
+
             strip.setPixelColor(
                 i, Color(colorarray[0], colorarray[1], colorarray[2]))
+
         strip.show()
         time.sleep(0.1)

--- a/examples/strandtest.py
+++ b/examples/strandtest.py
@@ -6,19 +6,18 @@
 # various animations on a strip of NeoPixels.
 
 import time
-from rpi_ws281x import *
+from rpi_ws281x import PixelStrip, Color
 import argparse
 
 # LED strip configuration:
-LED_COUNT      = 16      # Number of LED pixels.
-LED_PIN        = 18      # GPIO pin connected to the pixels (18 uses PWM!).
-#LED_PIN        = 10      # GPIO pin connected to the pixels (10 uses SPI /dev/spidev0.0).
-LED_FREQ_HZ    = 800000  # LED signal frequency in hertz (usually 800khz)
-LED_DMA        = 10      # DMA channel to use for generating signal (try 10)
-LED_BRIGHTNESS = 255     # Set to 0 for darkest and 255 for brightest
-LED_INVERT     = False   # True to invert the signal (when using NPN transistor level shift)
-LED_CHANNEL    = 0       # set to '1' for GPIOs 13, 19, 41, 45 or 53
-
+LED_COUNT = 16        # Number of LED pixels.
+LED_PIN = 18          # GPIO pin connected to the pixels (18 uses PWM!).
+# LED_PIN = 10        # GPIO pin connected to the pixels (10 uses SPI /dev/spidev0.0).
+LED_FREQ_HZ = 800000  # LED signal frequency in hertz (usually 800khz)
+LED_DMA = 10          # DMA channel to use for generating signal (try 10)
+LED_BRIGHTNESS = 255  # Set to 0 for darkest and 255 for brightest
+LED_INVERT = False    # True to invert the signal (when using NPN transistor level shift)
+LED_CHANNEL = 0       # set to '1' for GPIOs 13, 19, 41, 45 or 53
 
 
 # Define functions which animate LEDs in various ways.
@@ -27,18 +26,20 @@ def colorWipe(strip, color, wait_ms=50):
     for i in range(strip.numPixels()):
         strip.setPixelColor(i, color)
         strip.show()
-        time.sleep(wait_ms/1000.0)
+        time.sleep(wait_ms / 1000.0)
+
 
 def theaterChase(strip, color, wait_ms=50, iterations=10):
     """Movie theater light style chaser animation."""
     for j in range(iterations):
         for q in range(3):
             for i in range(0, strip.numPixels(), 3):
-                strip.setPixelColor(i+q, color)
+                strip.setPixelColor(i + q, color)
             strip.show()
-            time.sleep(wait_ms/1000.0)
+            time.sleep(wait_ms / 1000.0)
             for i in range(0, strip.numPixels(), 3):
-                strip.setPixelColor(i+q, 0)
+                strip.setPixelColor(i + q, 0)
+
 
 def wheel(pos):
     """Generate rainbow colors across 0-255 positions."""
@@ -51,32 +52,37 @@ def wheel(pos):
         pos -= 170
         return Color(0, pos * 3, 255 - pos * 3)
 
+
 def rainbow(strip, wait_ms=20, iterations=1):
     """Draw rainbow that fades across all pixels at once."""
-    for j in range(256*iterations):
+    for j in range(256 * iterations):
         for i in range(strip.numPixels()):
-            strip.setPixelColor(i, wheel((i+j) & 255))
+            strip.setPixelColor(i, wheel((i + j) & 255))
         strip.show()
-        time.sleep(wait_ms/1000.0)
+        time.sleep(wait_ms / 1000.0)
+
 
 def rainbowCycle(strip, wait_ms=20, iterations=5):
     """Draw rainbow that uniformly distributes itself across all pixels."""
-    for j in range(256*iterations):
+    for j in range(256 * iterations):
         for i in range(strip.numPixels()):
-            strip.setPixelColor(i, wheel((int(i * 256 / strip.numPixels()) + j) & 255))
+            strip.setPixelColor(i, wheel(
+                (int(i * 256 / strip.numPixels()) + j) & 255))
         strip.show()
-        time.sleep(wait_ms/1000.0)
+        time.sleep(wait_ms / 1000.0)
+
 
 def theaterChaseRainbow(strip, wait_ms=50):
     """Rainbow movie theater light style chaser animation."""
     for j in range(256):
         for q in range(3):
             for i in range(0, strip.numPixels(), 3):
-                strip.setPixelColor(i+q, wheel((i+j) % 255))
+                strip.setPixelColor(i + q, wheel((i + j) % 255))
             strip.show()
-            time.sleep(wait_ms/1000.0)
+            time.sleep(wait_ms / 1000.0)
             for i in range(0, strip.numPixels(), 3):
-                strip.setPixelColor(i+q, 0)
+                strip.setPixelColor(i + q, 0)
+
 
 # Main program logic follows:
 if __name__ == '__main__':
@@ -86,30 +92,30 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     # Create NeoPixel object with appropriate configuration.
-    strip = Adafruit_NeoPixel(LED_COUNT, LED_PIN, LED_FREQ_HZ, LED_DMA, LED_INVERT, LED_BRIGHTNESS, LED_CHANNEL)
+    strip = PixelStrip(LED_COUNT, LED_PIN, LED_FREQ_HZ, LED_DMA, LED_INVERT, LED_BRIGHTNESS, LED_CHANNEL)
     # Intialize the library (must be called once before other functions).
     strip.begin()
 
-    print ('Press Ctrl-C to quit.')
+    print('Press Ctrl-C to quit.')
     if not args.clear:
         print('Use "-c" argument to clear LEDs on exit')
 
     try:
 
         while True:
-            print ('Color wipe animations.')
+            print('Color wipe animations.')
             colorWipe(strip, Color(255, 0, 0))  # Red wipe
             colorWipe(strip, Color(0, 255, 0))  # Blue wipe
             colorWipe(strip, Color(0, 0, 255))  # Green wipe
-            print ('Theater chase animations.')
+            print('Theater chase animations.')
             theaterChase(strip, Color(127, 127, 127))  # White theater chase
-            theaterChase(strip, Color(127,   0,   0))  # Red theater chase
-            theaterChase(strip, Color(  0,   0, 127))  # Blue theater chase
-            print ('Rainbow animations.')
+            theaterChase(strip, Color(127, 0, 0))  # Red theater chase
+            theaterChase(strip, Color(0, 0, 127))  # Blue theater chase
+            print('Rainbow animations.')
             rainbow(strip)
             rainbowCycle(strip)
             theaterChaseRainbow(strip)
 
     except KeyboardInterrupt:
         if args.clear:
-            colorWipe(strip, Color(0,0,0), 10)
+            colorWipe(strip, Color(0, 0, 0), 10)


### PR DESCRIPTION
Cleanup as suggested in https://github.com/jgarff/rpi_ws281x/issues/252

Fixes all issues raised by Flake8 except for "E501 line too long".

Additionally migrates from star imports to `from rpi_ws281x import Color, PixelStrip, ws` and moves away from the `Adafruit_NeoPixel` shim class to `PixelStrip`.