### PR TITLE
Fixes cross compile building with Buildroot

### DIFF
--- a/library/setup.py
+++ b/library/setup.py
@@ -1,19 +1,15 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Python wrapper for the rpi_ws281x library.
 # Authors:
-#    Phil Howard (phil@pimoroni.com) 
+#    Phil Howard (phil@pimoroni.com)
 #    Tony DiCola (tony@tonydicola.com)
 
 from setuptools import setup, find_packages, Extension
 from setuptools.command.build_py import build_py
-import subprocess
 
 class CustomInstallCommand(build_py):
-    """Customized install to run library Makefile"""
     def run(self):
         print("Compiling ws281x library...")
-        proc =subprocess.Popen(["make"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        print(proc.stderr.read())
         build_py.run(self)
 
 setup(name              = 'rpi_ws281x',
@@ -26,8 +22,13 @@ setup(name              = 'rpi_ws281x',
       url               = 'https://github.com/rpi-ws281x/rpi-ws281x-python/',
       cmdclass          = {'build_py':CustomInstallCommand},
       packages          = ['rpi_ws281x'],
-      ext_modules       = [Extension('_rpi_ws281x', 
-                                     sources=['rpi_ws281x_wrap.c'],
-                                     include_dirs=['lib/'],
-                                     library_dirs=['lib-built/'],
-                                     libraries=['ws2811'])])
+      ext_modules       = [Extension('_rpi_ws281x',
+                                     include_dirs = ['.'],
+                                     sources = ['rpi_ws281x_wrap.c',
+                                              'lib/dma.c',
+                                              'lib/mailbox.c',
+                                              'lib/main.c',
+                                              'lib/pcm.c',
+                                              'lib/pwm.c',
+                                              'lib/rpihw.c',
+                                              'lib/ws2811.c'])])

--- a/library/setup.py
+++ b/library/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # Python wrapper for the rpi_ws281x library.
 # Authors:
 #    Phil Howard (phil@pimoroni.com)


### PR DESCRIPTION
Hi!

I had a hard time trying to build this library using the standard Buildroot "python-package". The library always ended built for the Host triplet instead of the Target. This setup.py modification avoid the use of the Makefile, building the ws281x library using the setup.py. This way the library is cross compiled correctly in Buidlroot, as well as, using the usual "python setup.py build".

Let me know your thoughts.

Gerardo.