### PR TITLE
Update rpi_ws281x.py

### DIFF
--- a/library/rpi_ws281x/rpi_ws281x.py
+++ b/library/rpi_ws281x/rpi_ws281x.py
@@ -111,6 +111,7 @@ class PixelStrip(object):
     def _cleanup(self):
         # Clean up memory used by the library when not needed anymore.
         if self._leds is not None:
+            ws.ws2811_fini(self.leds)
             ws.delete_ws2811_t(self._leds)
             self._leds = None
             self._channel = None


### PR DESCRIPTION
Need to call ws2811_fini() before calling delete_ws2811_t() to ensure DMA is finished when terminating.

I ran into an issue where repeatedly instantiating the rpi_ws281x module and shutting it down (about several hundred invocations) was causing subsequent instantiations to fail with a `ws2811_init failed with code -2`. There was plenty of memory, but something was messed up -- I had to reboot my Pi to get it working again.

After adding the ws2811_fini(), I no longer see this issue (could run it for several thousand invocations). 

I tested it with Rpi 0w, with Unicorn pHat.

see example shut down code in:
https://github.com/jgarff/rpi_ws281x/blob/master/python/examples/lowlevel.py