### PR TITLE
Update rpi_ws281x.py

### DIFF
--- a/library/rpi_ws281x/rpi_ws281x.py
+++ b/library/rpi_ws281x/rpi_ws281x.py
@@ -111,7 +111,7 @@ class PixelStrip(object):
     def _cleanup(self):
         # Clean up memory used by the library when not needed anymore.
         if self._leds is not None:
-            ws.ws2811_fini(self.leds)
+            ws.ws2811_fini(self._leds)
             ws.delete_ws2811_t(self._leds)
             self._leds = None
             self._channel = None


### PR DESCRIPTION
fixed a typo (missed an underscore!)

This is a follow up on my previous pull request #31 

I was testing this on a separate environment, and had a typo while I was copying this code for the PR. I tested this code to make sure there were no issues.