### PR TITLE
Added getPixelColorRGBW to include White

### DIFF
--- a/library/rpi_ws281x/rpi_ws281x.py
+++ b/library/rpi_ws281x/rpi_ws281x.py
@@ -178,6 +178,14 @@ class PixelStrip(object):
         setattr(c, 'g', self._led_data[n] >> 8  & 0xff)
         setattr(c, 'b', self._led_data[n]    & 0xff)
         return c
+    
+    def getPixelColorRGBW(self, n):
+        c = lambda: None
+        setattr(c, 'w', self._led_data[n] >> 24 & 0xff)
+        setattr(c, 'r', self._led_data[n] >> 16 & 0xff)
+        setattr(c, 'g', self._led_data[n] >> 8  & 0xff)
+        setattr(c, 'b', self._led_data[n]    & 0xff)
+        return c
 
 # Shim for back-compatibility
 class Adafruit_NeoPixel(PixelStrip):


### PR DESCRIPTION
Hi,
I would live to retrieve the white color aswell in the same clean way instead of doing it manually with the getPixelColor().
Ty for this amazing code, I was able to do an awesome led project with rpi, bluetooth and a phone app.