### PR TITLE
fix(Readme): repo url of C library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RPi WS281x Python
 
-This is the official Python distribution of the ws281x library: http://github.com/richardghirst/rpi_ws281x
+This is the official Python distribution of the ws281x library: http://github.com/jgarff/rpi_ws281x
 
 # Installing
 


### PR DESCRIPTION
It is the repository used in .gitmodules

Also it is more recently updated
