### PR TITLE
Fix slice assignment and ensure int() cast is done

### DIFF
--- a/library/rpi_ws281x/rpi_ws281x.py
+++ b/library/rpi_ws281x/rpi_ws281x.py
@@ -106,14 +106,19 @@ class PixelStrip:
 
     def __setitem__(self, pos, value):
         """Set the 24-bit RGB color value at the provided position or slice of
-        positions.
+        positions. If value is a slice it is zip()'ed with pos to set as many
+        leds as there are values.
         """
         # Handle if a slice of positions are passed in by setting the appropriate
         # LED data values to the provided value.
         # Cast to int() as value may be a numpy non-int value.
         if isinstance(pos, slice):
-            for n in range(*pos.indices(self.size)):
-                ws.ws2811_led_set(self._channel, n, int(value))
+            try:
+                for n, c in zip(range(*pos.indices(self.size)), value):
+                    ws.ws2811_led_set(self._channel, n, int(c))
+            except TypeError:
+                for n in range(*pos.indices(self.size)):
+                    ws.ws2811_led_set(self._channel, n, int(value))
         # Else assume the passed in value is a number to the position.
         else:
             return ws.ws2811_led_set(self._channel, pos, int(value))

--- a/library/rpi_ws281x/rpi_ws281x.py
+++ b/library/rpi_ws281x/rpi_ws281x.py
@@ -110,12 +110,13 @@ class PixelStrip:
         """
         # Handle if a slice of positions are passed in by setting the appropriate
         # LED data values to the provided value.
+        # Cast to int() as value may be a numpy non-int value.
         if isinstance(pos, slice):
             for n in range(*pos.indices(self.size)):
-                ws.ws2811_led_set(self._channel, n, value)
+                ws.ws2811_led_set(self._channel, n, int(value))
         # Else assume the passed in value is a number to the position.
         else:
-            return ws.ws2811_led_set(self._channel, pos, value)
+            return ws.ws2811_led_set(self._channel, pos, int(value))
 
     def __len__(self):
         return ws.ws2811_channel_t_count_get(self._channel)


### PR DESCRIPTION
I use the slice assignment which was removed (probably by accident) in f80276b.
This restores it.

There is also an issue in sending slices from a numpy array as even a numpy.uint32 is not accepted:
  TypeError: in method 'ws2811_led_set', argument 3 of type 'uint32_t'

This could fix #115 